### PR TITLE
Fix : Handle non annotated git tags(lightweight tags) with --tags option

### DIFF
--- a/src/dynamic_versioning/utils.py
+++ b/src/dynamic_versioning/utils.py
@@ -175,10 +175,11 @@ class GitDescribeError(DynamicVersioningError):
 
 def _git_describe(project_dir: pathlib.Path) -> str:
     '''
-    Perform a git describe --long and return the output.
+    Perform a git describe --long --tags and return the output.
+    The --tags option will get the non annotated git tags.
     '''
     # perform the git describe
-    command = ["git", "describe", "--long"]
+    command = ["git", "describe", "--long", "--tags"]
     with subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=project_dir) as proc:
         out, err = proc.communicate()
 


### PR DESCRIPTION
I found an issue when i tried to release a new package with the dynamic_versioning  tool based on the latest tag, a NoAnnotatedTagError exception was raised  but the tag should have been taken into account (as it is the last released tag).

The command `git describe --long --tags` solves this problem, so i added the` --tags` option to handle non annotated tags as it can be the case for a lot of git tags.

Thanks for your feedback.